### PR TITLE
Draft of the Simple Message Assigned Message Identifiers REP

### DIFF
--- a/rep-I0004.rst
+++ b/rep-I0004.rst
@@ -1,9 +1,9 @@
 ::
 
-  REP: XXX
+  REP: I0004
   Title: Assigned Message Identifiers for the Simple Message Protocol
   Author: G.A. vd. Hoorn <g.a.vanderhoorn@tudelft.nl>
-  Status: Draft
+  Status: Active
   Type: Process
   Content-Type: text/x-rst
   Created: 01-Jun-2014


### PR DESCRIPTION
This PR proposes a REP that would document all 'assigned' message type identifiers as used in `simple_message`. I think it is important to manage the use of these identifiers centrally, as ad-hoc usage of `msg_type` values could lead to really nasty problems.

Link to the rendered document: [link](https://github.com/gavanderhoorn/rep-ros-i/blob/rep-xxxx_assigned_msg_ids/rep-ixxxx.rst).

Todo:
- the REP should probably reserve a range as _freely usable_, similar to the _Vendor specific_ ranges.
- I'm not too sure about the _application procedure_: I feel it is important to formalise it a bit, but it should also not be too formal / rigid. I think an approach similar to how REPs in general are reviewed and voted on would be a good compromise.
- the `msg_type` field is currently a `shared_int`, and is (de)serialised by classes in `simple_message` as a signed integer, which would make negative IDs valid values for the field. I assume that is not really a design choice, but more a consequence of how the _shared types_ system was set up? If it is intentional, the negative IDs should be listed in the table as well.
