### PR TITLE
Fix misc rst markup issues in REPs 1, 2 and 3

### DIFF
--- a/rep-I0001.rst
+++ b/rep-I0001.rst
@@ -1,5 +1,5 @@
 ::
-    
+
     REP: I0001
     Title: Industrial Robot Controller Motion/Status Interface (Version 2)
     Author: Shaun Edwards
@@ -31,7 +31,7 @@ Abstract
 This REP specifies the second version of the ROS-Industrial robot controller client/server motion/state/status interface [#rbt_clnt]_.  It is relevant to anybody using ROS-I standard libraries to communicate with an industrial robot controller.  Note: This spec does not specify the ROS API [#ros_api]_, which is specified separately.  However, it does make some assumptions about the interface which are not explicitly defined by the API but are assumed by higher level packages like MoveIt [#moveit]_.
 
 Definitions
-=========
+===========
 
 The following definitions are used throughout:
  * joint, axis - A single controllable item.  Typically revolute(rotational) or linear motion.
@@ -46,67 +46,71 @@ The first version of the motion/status interface (loosely documented in code and
 
 
 Requirements
-=========
+============
 
 The industrial robot controller motion interface shall meet the following requirements:
  * A single node shall act as the point of control (motion).  All trajectory topics shall be routed through this node to the controller.  This not only simplifies implementation (a controller communicates with a single client) but single point control is key tenant of safety and predictable systems.
  * It shall allow for synchronous and asynchronous control of single and multiple arms (i.e. a unified driver that allows for different types of control to be achieved dynamically without reconfiguration)
  * All incoming joint trajectories should be fully populated with at least position, velocity, acceleration, and timing information [#traj_msg]_. (NOTE: Certain controllers may not require all data, but this will be different between controllers).
  * Effort/force control shall be supported by the messaging structure but not required for robot motion control.  Most industrial platforms do not offer this capability.  This requirement allows for some level of future proofing and expansion in the future.
- * Joint groups shall be statically defined at the controller level.  ROS trajectories must define motion for all the joints in a group (NOTE: Some controllers have additional axes that aren't used by all robots.  In these cases the axes are ignored by the controller.  However, the motion node should be smart enough to reorder or shift joint values based on configuration data). 
+ * Joint groups shall be statically defined at the controller level.  ROS trajectories must define motion for all the joints in a group (NOTE: Some controllers have additional axes that aren't used by all robots.  In these cases the axes are ignored by the controller.  However, the motion node should be smart enough to reorder or shift joint values based on configuration data).
  * Joint trajectories shall be executed one at a time.  Receipt of a new trajectory before the current trajectory is finished shall either result in a motion stop, followed by the execution of the new trajectory.
  * A single node shall publish joint/robot state information, utilizing a single common connection to the controller.
  * Joint states shall be sent from the controller to that robot state node in a single dynamic message that encompasses all groups.
  * Group status shall be sent from the controller to that robot state node in a single dynamic message that encompasses all groups.
  * The controller joint group structure shall be statically defined at node start up (i.e. in a yaml file read on node construction).  Motion groups are predefined (statically) by most controllers.
- 
+
 Design Assumptions
-=========
+==================
+
 The following assumptions are inherent in the client/server design:
  * All joints (regardless of group) shall be uniquely named.
- 
- 
+
+
 Simple Message Structures
-=========
+=========================
+
 The simple message package [#simp_msg]_ provides libraries for communicating with industrial robot controllers.  This includes connection handling libraries and message packing/unpacking capabilities.  The default robot connection is TCP/IP, although any method of transferring byte data is easily supported.  While not required, traditional message structures have been statically defined (i.e. fixed arrays).  This is because robot controllers cannot dynamically allocate memory.  If dynamic messages are used, controller side servers should utilize fixed size data that comply with some physical limitation (i.e. the controller can only handle ten axes in a single group) and then handle the error cases when the simple message exceeds that amount.  By creating dynamic simple messages for motion and status, multiple arm control and monitoring can be achieved.
 
 
 Dynamic Joint Point
----------
+-------------------
+
 The dynamic joint point is meant to mimic the ROS JointTrajectory message structure [#traj_msg]_.  A one-to-one mapping of the joints included in the ROS message to the simple message shall be created.  By encapsulating the entire trajectory in a single message, synchronized motion is possible.::
 
-    length: true message/data length 
+    length: true message/data length
     header: standard msg_type, comms_type, reply_code fields
     sequence:
-    num_groups: # of motion groups included in this message 
+    num_groups: # of motion groups included in this message
     group[]: # length of this array must match num_groups
-        id:   control-group ID for use on-controller 
+        id:   control-group ID for use on-controller
         num_joints: # of joints in this motion group
         valid_fields: #bit field for following items
         # length of the following items must match num_joints, order set by controller.  Invalid fields (see bit field above) are not included, resulting in a shorter message.
         positions[]
-        velocities[] 
-        accelerations[] 
-        effort[] 
+        velocities[]
+        accelerations[]
+        effort[]
         time_from_start
-    
-    
+
+
 Dynamic Joint State
----------
+-------------------
+
 The dynamic joint state is meant to mimic both the ROS JointState and FollowJointTrajectoryFeedback message.  The JointState message specifies the current kinematic/dynamic state of the robot.  The feedback message specifies the current control state of the system (this may or may not be available on all systems).::
 
-    length: true message/data length 
+    length: true message/data length
     header: standard msg_type, comms_type, reply_code fields
     sequence:
-    num_groups: # of motion groups included in this message 
+    num_groups: # of motion groups included in this message
     group[]: # length of this array must match num_groups
-        id:   control-group ID for use on-controller 
-        num_joints: # of joints in this motion group 
+        id:   control-group ID for use on-controller
+        num_joints: # of joints in this motion group
         valid_fields: #bit field for following items
         # length of the following items must match num_joints, order set by controller.  Invalid fields (see bit field above) are not included, resulting in a shorter message.
         positions[]
-        velocities[] 
-        accelerations[] 
+        velocities[]
+        accelerations[]
         effort[]
         position_desired[]
         position_errors[]
@@ -114,17 +118,17 @@ The dynamic joint state is meant to mimic both the ROS JointState and FollowJoin
         velocity_errors[]
         effort_desired[]
         effort_error[]
-    
-    
+
+
 Dynamic Group Status
----------
+--------------------
 The dynamic group status is meant to mimic both the ROS-I RobotStatus message.  See the RobotStatus message[#rbt_stat]_ for field descriptions.::
 
-    length: true message/data length 
-    header: standard msg_type, comms_type, reply_code fields 
-    num_groups: # of motion groups included in this message 
+    length: true message/data length
+    header: standard msg_type, comms_type, reply_code fields
+    num_groups: # of motion groups included in this message
     group[]: # length of this array must match num_groups
-        id:   control-group ID for use on-controller 
+        id:   control-group ID for use on-controller
         mode:
         e_stopped:
         drives_powered:
@@ -134,29 +138,30 @@ The dynamic group status is meant to mimic both the ROS-I RobotStatus message.  
 
 
 Communications Method
-========= 
+=====================
+
 The communications method between the ROS PC and robot controller will not change with this REP.   It will continue to be via TCP sockets.  This REP covers two existing socket connections: motion on one socket, and state and status on a separate socket.
 
 Motion Interface
-=========
+================
 
 Motion Downloading Vs Streaming
----------
+-------------------------------
 In the first version of the motion interface, some robots allowed motion streaming (i.e. point by point) and others required motion downloading (i.e. entire trajectory).  This distinction was invisible to the user, as the ROS interface receives entire trajectories in a single message.  Motion download interfaces were created because it was thought that they would provide better (smoother and faster) motion, this hasn't been found to be true.  Dense trajectories resulted in the same slow, disjointed motion as motion streaming interfaces.  For the purposes of this second version, only streaming interfaces will be considered.  This simplifies the problem of switching between synchronous and asynchronous motion.
 
 Motion Variants
----------
+---------------
 The motion interface can be expressed as four variations:
  * Single Arm - Only a single arm group is defined, no synchronization required.
  * Multi-Arm (Sync) - Multiple arms are defined.  A single joint trajectory containing all joints is received and sent to the controller in a single simple message.  The controller receives the message and performs synchronized motion.
  * Multi-Arm (Async) - Multiple arms are defined.  Multiple joint trajectories for each arm/motion group are received and sent to the controller in independent messages.  The controller receives the messages and performs asynchronous motion.  NOTE: Although this may look like synchronized motion there isn't a real time guarantee that the waypoints across multiple groups are reached at the same time.
- * Multi-Arm (Sync & Async) - Combination of the two above operating modes.  
- 
+ * Multi-Arm (Sync & Async) - Combination of the two above operating modes.
+
  .. image:: rep-I0001/motion_interface.png
- 
+
 Node Configuration
----------
-In order to support the various methods of control, the motion node must be somewhat dynamic/statically reconfigurable[see current parameters].  The node must be able to support subscriptions to multiple topics (all of the same type) as well as conversion from ROS group organizations to controller organization.  This mapping would look similar to the MoveIt controller manager[#ctrl_mgr]_.  
+------------------
+In order to support the various methods of control, the motion node must be somewhat dynamic/statically reconfigurable[see current parameters].  The node must be able to support subscriptions to multiple topics (all of the same type) as well as conversion from ROS group organizations to controller organization.  This mapping would look similar to the MoveIt controller manager[#ctrl_mgr]_.
 The yaml file will contain a list of structures that defines the joint trajectory topics as well as the mapping to the controller.::
 
         topic_list:
@@ -171,19 +176,20 @@ The yaml file will contain a list of structures that defines the joint trajector
            ns: ...
 
 State Interface
-=========
+===============
+
 The robot state interface encapsulates all the data coming FROM the robot controller, including joint position, velocity (if available), effort(if available), position error and general robot status information [#rbt_stat]_.  The implementation of the state interface is simpler than the motion interface because it can be generalized to the multi-arm case, where a single arm is just a specific example.
 
 The state interface is split into a joint state and robot status interface (although they will utilize the same socket connection, see `Communications Method`_).  The split allows joint state feedback to be sent at a higher rate than status information (which should change slowly).
  * Joint State - A single controller message is split into N JointState messages.
  * Robot Status - A single controller message that contains status information for each arm.
- 
+
  .. image:: rep-I0001/state_interface.png
- 
- 
+
+
 Node Configuration
----------
-Similar to the motion interface, the state interface will require configuration.  The state interface will have to parse messages coming from the robot and convert the date into the desired ROS topics.  The level of configuration available on the robot controller will vary, so the messages coming from the controller may be more or less dynamic.  The state node, based on configuration, will identify the pertinent information from the robot controller and convert to ROS topics.  Additional information will be ignored.  
+------------------
+Similar to the motion interface, the state interface will require configuration.  The state interface will have to parse messages coming from the robot and convert the date into the desired ROS topics.  The level of configuration available on the robot controller will vary, so the messages coming from the controller may be more or less dynamic.  The state node, based on configuration, will identify the pertinent information from the robot controller and convert to ROS topics.  Additional information will be ignored.
 
 The yaml file will contain a list of structures that defines the joint trajectory/status topics as well as the mapping to the controller.  Note, this configuration is very similar to the motion node, with the exception that the state node performs a one-to-one mapping from controller groups to topics.  The motion node, in addition to this, can perform a one(topic) to many (groups) mapping.::
 
@@ -201,22 +207,24 @@ The yaml file will contain a list of structures that defines the joint trajector
            - name: <topic name>
            - ns: <topic namespace>
            ...
- 
+
 Backwards Compatibility
-=========
+=======================
+
 This REP creates a new industrial robot client package that will not be backwards compaptible with the previous version.  This means that all servers will have to be rewritten to support this new client.  Because this REP does not change the ROS API (except for multi-arm considerations), the previous client/server versions can continue to be used as is.  Transition to the client/servers described by this REP can be a gradual process as the capabilities enabled by this new design are required.
 
-If incompatible client/server combinations are ever used, there is little risk of undesirable behavior.  Because the simple message base protocol is not changed by this REP, the client/server should recognize the new message types as undefined and return an error reply code.  
+If incompatible client/server combinations are ever used, there is little risk of undesirable behavior.  Because the simple message base protocol is not changed by this REP, the client/server should recognize the new message types as undefined and return an error reply code.
 
 Todo's
-=========
+======
+
 The following items still need to be addressed:
  * Topics and Services - The ROS API defines topics and services for receiving trajectories.  This should also be supported by the new nodes.
  * Controller/PC handshaking - Currently most robot/PC communications involves a handshake (either I received and processed the last message or the last message resulted in an error).  This results in robust communications and execution, but doubles the amount of latency in the system.  I think this is the appropriate design, but it may be up for discussion.
- * What to do about force/effort control.  It is not currently supported by many controllers, but may be in the future.  
+ * What to do about force/effort control.  It is not currently supported by many controllers, but may be in the future.
  * What is the failure mechanism when an incomplete trajectory point is sent? impossible trajectory point (too fast, too much acceleration)?
  * Support for joint trajectory splicing should be added (implementation should be simpler now that trajectories are streamed point by point).
- 
+
 References
 ==========
 .. [#rbt_clnt] ROS-Industrial robot client ( http://wiki.ros.org/industrial_robot_client ).

--- a/rep-I0002.rst
+++ b/rep-I0002.rst
@@ -1,5 +1,4 @@
 ::
-    
     REP: I0002
     Title: Industrial Systems Calibration Methods/Routine
     Author: Christina Gomez
@@ -34,7 +33,8 @@ Every industrial system with a measurement component or multiple pieces of equip
 
 
 Definitions
-=========
+===========
+
 The following definitions are used throughout:
  * extrinsics - 6 pose parameters defining the position in space, specificially with rotation as a Rodriques’ axis-angle vector[ax, ay, az], and translation as vector [x, y, z]
  * intrinsics(camera) - 9 camera parameters defining the internal structure of the camera, specifically focal lengths (fx, fy), pixel centers (cx, cy) and 5 distortion parameters (k1, k2, k3, p1, p2)
@@ -42,15 +42,15 @@ The following definitions are used throughout:
  * target - The pattern (checkerboard/circle grid) with known point positions (checkerboard corners, circle grid circle centers, etc.)
 
 Requirements
-=========
+============
 
-To control for each scenario there are several variables, such as the number of sensors, whether or not they are moving, the number and types of targets and whether or not they are moving, the number of targets within view, the number of sensors that can view a single target, and whether or not any of the positions of the targets are known. 
+To control for each scenario there are several variables, such as the number of sensors, whether or not they are moving, the number and types of targets and whether or not they are moving, the number of targets within view, the number of sensors that can view a single target, and whether or not any of the positions of the targets are known.
 This package must take these variations in scenario into account to provide a generalized solution for various industrial systems
 
-Example of such systems are as follows: 
- * A camera setup to view a robot workspace requires the camera and the robot to share a common frame; 
- * A system of cameras controls a process and are required to be continuously calibrated; 
- 
+Example of such systems are as follows:
+ * A camera setup to view a robot workspace requires the camera and the robot to share a common frame;
+ * A system of cameras controls a process and are required to be continuously calibrated;
+
 Scenerios where extrinsic calibration can be used
  * Camera to camera
  * Camera to Robot
@@ -58,51 +58,54 @@ Scenerios where extrinsic calibration can be used
  * Robot to reference system
  * Camera to fixture
  * Robot to fixture
- 
+
 Sensor Types
  * Cameras
  * Range finders
  * Laser trackers
  * Robot/Positioning system (Forward Kinematics)
  * TODO: Complete list
+
 When appropriate (i.e. if it drastically improves calibration) a sensor model should be utilized as part of the optimization process.  For example, including the camera projection and it's associated error model can greatly increase the accuracy of a calibration.  Under such a model targets closer to the camera can be measure more accruatley than those that are further away.  By including this "model" in the optimization, a better calibration results.
- 
+
 Target types
  * Fiducials(spheres, LEDs)
  * AR tags
  * Checkerboards
  * Circle patterns
  * TODO: Complete list
- 
+
 The desired package should be implemented in a ROS agnostic fashion, such that it could be generically used in any piece of software(i.e with minimal dependencies).
- 
+
 Design Assumptions
-========= 
+==================
 
 Specification
-=========
+=============
+
 The calibration executables will take three input yaml files. These files define the sensors(s), target(s) and job parameters.
-The target.yaml file contains a list of static and/or moving targets. The static target is defined by a name, it's pose (angle axis format of rotation ax, ay, az, and translations x, y, and z), the number of measurable points, and a list of those points locations within that target. The moving target requires all the same information specified as the static target, but also a scene_id. 
+The target.yaml file contains a list of static and/or moving targets. The static target is defined by a name, it's pose (angle axis format of rotation ax, ay, az, and translations x, y, and z), the number of measurable points, and a list of those points locations within that target. The moving target requires all the same information specified as the static target, but also a scene_id.
 
 TODO: More details on camera and cal_job yaml input files to go here.
 
 Rationale
-==========
+=========
 
 Todo's
-=========
- 
+======
+
 Reference Implementation
-==========
- 
+========================
+
 References
 ==========
+
 Copyright
 =========
 
 This document has been placed in the public domain.
 
- 
+
 ..
    Local Variables:
    mode: indented-text

--- a/rep-I0003.rst
+++ b/rep-I0003.rst
@@ -1,5 +1,4 @@
 ::
-    
     REP: I0003
     Title: Cartesian Path Planner Interface Pipeline
     Author: Shaun Edwards, Dan Solomon, Jorge Nicho, Chris Lewis, Paul Hvass, Jeremy Zoss, Clay Flannigan
@@ -34,27 +33,30 @@ The current MoveIt/ROS interfaces are focused on pick and place applications.  I
 
 
 Definitions
-=========
+===========
+
 The following definitions are used throughout:
  * semi-constrained path - a path in which at least part of the path has some allowance for variation.
 
 Requirements
-=========
+============
+
  * At a high level, the pipeline shall take a semi-constrained Cartesian path as input and output a joint trajectory for manipulator execution.
  * The pipeline shall have a ROS and C++ API.  The ROS API should support the most common use cases, but can be more limited than the full C++ API
  * The pipeline structure should be implemented in an abstract manor, such that steps within the pipeline can be overridden with custom functionality.  NOTE: This can be accomplished using traditional object oriented techniques.  Use of plugins is not a requirement (at this time).
 
 Design Assumptions
-========= 
+==================
 
 Specification
-=========
+=============
 
 ROS API
-=========
+=======
+
 The ROS API defines the topics, services, actions, and parameters by which external ROS nodes can interact with the pipeline.
 
-The definition of a process path plan is a key concept in the ROS API (as well as other APIs).  A process path plan defines the waypoints and segments for a path.  Each waypoint shall be defined by a set of constraints.  
+The definition of a process path plan is a key concept in the ROS API (as well as other APIs).  A process path plan defines the waypoints and segments for a path.  Each waypoint shall be defined by a set of constraints.
 **Process Path Definition**
 ::
 
@@ -71,17 +73,16 @@ The definition of a process path plan is a key concept in the ROS API (as well a
             type (linear, joint, circular)
             acceleration
             velocity
-   
 
 Rationale
-==========
+=========
 
 Todo's
-=========
- 
+======
+
 Reference Implementation
-==========
- 
+========================
+
 References
 ==========
 
@@ -90,7 +91,7 @@ Copyright
 
 This document has been placed in the public domain.
 
- 
+
 ..
    Local Variables:
    mode: indented-text


### PR DESCRIPTION
Noticed these while testing out `doc8` (#21).

No content changes, just rst markup.

Remaining issue that `doc8` complains about is `D001 Line too long`, which is caused by the fact that none of the REPs wrap lines.
